### PR TITLE
회원가입, 로그인 API 연동

### DIFF
--- a/src/api/instance.js
+++ b/src/api/instance.js
@@ -1,0 +1,56 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: "https://a-log.site/api",
+});
+
+// 요청 인터셉터: access token 자동 첨부
+api.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem("jwtToken");
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+// 응답 인터셉터: 401 발생 시 refresh 시도
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+    if (
+      error.response &&
+      error.response.status === 401 &&
+      !originalRequest._retry
+    ) {
+      originalRequest._retry = true;
+      try {
+        // refreshToken으로 accessToken 재발급
+        const refreshToken = localStorage.getItem("refreshToken");
+        const res = await axios.post(
+          "https://a-log.site/api/user-service/refresh-token",
+          { refreshToken }
+        );
+        const newAccessToken = res.data.data.accessToken;
+        localStorage.setItem("jwtToken", newAccessToken);
+
+        // 원래 요청에 새 토큰 적용 후 재시도
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        return api(originalRequest);
+      } catch (refreshError) {
+        // refresh도 실패하면 로그아웃 처리
+        localStorage.removeItem("jwtToken");
+        localStorage.removeItem("refreshToken");
+        localStorage.removeItem("userId");
+        window.location.href = "/login";
+        return Promise.reject(refreshError);
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default api; 

--- a/src/components/LogoutButtonComponent/LogoutButtonComponent.jsx
+++ b/src/components/LogoutButtonComponent/LogoutButtonComponent.jsx
@@ -7,12 +7,12 @@ export const LogoutComponent = ({ className, divClassName }) => {
   const navigate = useNavigate();
 
   const handleLogout = () => {
-    //예시: localStorage의 로그인 정보 제거
-    //localStorage.removeItem("isLoggedIn");
-    //localStorage.removeItem("user");
-
-    // ✅ 메인 페이지로 이동
-    navigate("/MainPageBefore");
+    // 인증 정보 삭제
+    localStorage.removeItem("jwtToken");
+    localStorage.removeItem("refreshToken");
+    localStorage.removeItem("userId");
+    // 메인 페이지로 이동
+    window.location.href = "/MainPageBefore";
   };
 
   return (

--- a/src/components/LogoutComponent/LogoutComponent.jsx
+++ b/src/components/LogoutComponent/LogoutComponent.jsx
@@ -8,10 +8,10 @@ export const LogoutComponent = ({ property1 = "default", text = "LOGOUT" }) => {
 
   const handleClick = () => {
     if (text === "LOGOUT") {
-      // 로그인 정보 삭제
-      localStorage.removeItem("isLoggedIn");
-      localStorage.removeItem("user");
-
+      // 인증 정보 삭제
+      localStorage.removeItem("jwtToken");
+      localStorage.removeItem("refreshToken");
+      localStorage.removeItem("userId");
       // 로그아웃 후 메인 페이지 이동
       navigate("/MainPageBefore");
     } else if (text === "LOGIN") {

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -7,7 +7,7 @@ import MailIcon from "../../icons/MailIcon/MailIcon";
 import HamburgerIcon from "../../icons/HamburgerIcon/HamburgerIcon";
 import { HamburgerScreen } from "../HamburgerScreen/HamburgerScreen";
 import { useAlarmStore } from "../../store/useAlarmStore";
-import axios from "axios";
+import api from "../../api/instance";
 import "./Navbar.css";
 import { useWebSocket } from "../../contexts/WebSocketContext";
 

--- a/src/contexts/WebSocketContext.jsx
+++ b/src/contexts/WebSocketContext.jsx
@@ -17,10 +17,14 @@ export const WebSocketProvider = ({ children }) => {
     if (!token) return;
 
     ws.current = new window.WebSocket(WS_URL);
-    ws.current.onopen = () => {
+
+    const handleOpen = () => {
+      console.log("WebSocket 연결됨");
       ws.current.send(JSON.stringify({ type: "AUTH", token }));
     };
-    ws.current.onmessage = (event) => {
+
+    ws.current.addEventListener("open", handleOpen);
+    ws.current.addEventListener("message", (event) => {
       const data = JSON.parse(event.data);
       if (data.type === "AUTH_SUCCESS") {
         setAuthSuccess(true);
@@ -29,9 +33,40 @@ export const WebSocketProvider = ({ children }) => {
         setUnreadTotalCount(data.totalUnreadCount);
       }
       setEventQueue((prev) => [...prev, data]);
-    };
+    });
+    ws.current.addEventListener("close", (e) => {
+      console.log("WebSocket 연결 닫힘", e);
+    });
+    ws.current.addEventListener("error", (e) => {
+      console.log("WebSocket 에러", e);
+    });
+
+    // 이미 연결된 상태라면 handleOpen 즉시 실행
+    if (ws.current.readyState === window.WebSocket.OPEN) {
+      handleOpen();
+    }
+
+    // 30초마다 ping 메시지 전송
+    const pingInterval = setInterval(() => {
+      if (ws.current && ws.current.readyState === window.WebSocket.OPEN) {
+        console.log("ping 전송!");
+        ws.current.send(JSON.stringify({ type: "ping" }));
+      }
+    }, 30000);
+
     return () => {
-      ws.current?.close();
+      try {
+        if (
+          ws.current &&
+          (ws.current.readyState === 0 || ws.current.readyState === 1) &&
+          typeof ws.current.close === "function"
+        ) {
+          ws.current.close();
+        }
+      } catch (e) {
+        // 연결이 이미 닫혔거나 예외 발생 시 무시
+      }
+      clearInterval(pingInterval);
     };
   }, []);
 

--- a/src/contexts/WebSocketContext.jsx
+++ b/src/contexts/WebSocketContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useRef, useState } from "react";
-import axios from "axios";
+import api from "../api/instance";
 
 const WS_URL = "wss://a-log.site/ws/chat";
 const WebSocketContext = createContext();
@@ -74,7 +74,7 @@ export const WebSocketProvider = ({ children }) => {
   useEffect(() => {
     if (authSuccess) {
       const token = localStorage.getItem("jwtToken");
-      axios.get("https://a-log.site/api/message-service/count/unread", {
+      api.get("message-service/count/unread", {
         headers: { Authorization: `Bearer ${token}` }
       })
       .then(res => {

--- a/src/screens/Login/Login.jsx
+++ b/src/screens/Login/Login.jsx
@@ -9,6 +9,7 @@ import AlogLogo from "../../icons/AlogLogo/AlogLogo";
 import "./Login.css";
 import PageTransitionWrapper from "../../components/PageTransitionWrapper/PageTransitionWrapper";
 import { AnimatePresence } from "framer-motion";
+import axios from "axios";
 
 export const Login = () => {
   const navigate = useNavigate();
@@ -17,19 +18,29 @@ export const Login = () => {
   const [password, setPassword] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
 
-  const dummyUser = {
-    id: "test",
-    password: "1234",
-  };
-
   const openModal = () => setShowModal(true);
   const closeModal = () => setShowModal(false);
 
-  const handleLogin = () => {
-    if (id === dummyUser.id && password === dummyUser.password) {
+  const handleLogin = async () => {
+    setErrorMessage(""); // 에러 초기화
+    try {
+      const response = await axios.post("https://a-log.site/api/user-service/signin", {
+        email: id,
+        password: password,
+      });
+
+      // 성공 응답 구조: { status, message, data: { accessToken, refreshToken, ... } }
+      const { accessToken, refreshToken } = response.data.data;
+
+      localStorage.setItem("jwtToken", accessToken);
+      localStorage.setItem("refreshToken", refreshToken);
+
       navigate("/MainPageAfter");
-    } else {
-      setErrorMessage("아이디 또는 비밀번호가 올바르지 않습니다.");
+    } catch (error) {
+      // 에러 응답 구조: { status, message, data }
+      const message =
+        error.response?.data?.message || "로그인에 실패했습니다.";
+      setErrorMessage(message);
     }
   };
 

--- a/src/screens/Login/Login.jsx
+++ b/src/screens/Login/Login.jsx
@@ -9,7 +9,7 @@ import AlogLogo from "../../icons/AlogLogo/AlogLogo";
 import "./Login.css";
 import PageTransitionWrapper from "../../components/PageTransitionWrapper/PageTransitionWrapper";
 import { AnimatePresence } from "framer-motion";
-import axios from "axios";
+import api from "../../api/instance";
 
 export const Login = () => {
   const navigate = useNavigate();
@@ -24,7 +24,7 @@ export const Login = () => {
   const handleLogin = async () => {
     setErrorMessage(""); // 에러 초기화
     try {
-      const response = await axios.post("https://a-log.site/api/user-service/signin", {
+      const response = await api.post("/user-service/signin", {
         email: id,
         password: password,
       });

--- a/src/screens/Login/Login.jsx
+++ b/src/screens/Login/Login.jsx
@@ -29,13 +29,16 @@ export const Login = () => {
         password: password,
       });
 
-      // 성공 응답 구조: { status, message, data: { accessToken, refreshToken, ... } }
-      const { accessToken, refreshToken } = response.data.data;
+      // 성공 응답 구조: { status, message, data: { accessToken, refreshToken, userId, ... } }
+      const { accessToken, refreshToken, userId } = response.data.data;
 
       localStorage.setItem("jwtToken", accessToken);
       localStorage.setItem("refreshToken", refreshToken);
+      if (userId) {
+        localStorage.setItem("userId", userId);
+      }
 
-      navigate("/MainPageAfter");
+      window.location.href = "/MainPageAfter";
     } catch (error) {
       // 에러 응답 구조: { status, message, data }
       const message =

--- a/src/screens/Message/Message.jsx
+++ b/src/screens/Message/Message.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import Navbar2 from "../../components/Navbar2/Navbar2";
 import PageTransitionWrapper from "../../components/PageTransitionWrapper/PageTransitionWrapper";
-import axios from "axios";
+import api from "../../api/instance";
 import "./Message.css";
 import { useWebSocket } from "../../contexts/WebSocketContext";
 
@@ -53,7 +53,7 @@ export const Message = () => {
     const fetchRooms = async () => {
       try {
         const token = localStorage.getItem("jwtToken");
-        const res = await axios.get("https://a-log.site/api/message-service/rooms", {
+        const res = await api.get("/message-service/rooms", {
           headers: { Authorization: `Bearer ${token}` },
         });
         setAllData(res.data.data || []);

--- a/src/screens/MessageRoom/MessageRoom.jsx
+++ b/src/screens/MessageRoom/MessageRoom.jsx
@@ -6,7 +6,7 @@ import MessageInput from "../../components/MessageInputBox/MessageInputBox";
 import CommunityRule from "../CommunityRule/CommunityRule";
 import MessageRoomExit from "../MessageRoomExit/MessageRoomExit";
 import PageTransitionWrapper from "../../components/PageTransitionWrapper/PageTransitionWrapper";
-import axios from "axios";
+import api from "../../api/instance";
 import "./MessageRoom.css";
 import { useWebSocket } from "../../contexts/WebSocketContext";
 
@@ -154,8 +154,8 @@ export const MessageRoom = () => {
     try {
       setLoading(true);
       const token = localStorage.getItem("jwtToken");
-      const response = await axios.get(
-        `https://a-log.site/api/message-service/with/${id}?page=${pageNum}&size=10`,
+      const response = await api.get(
+        `/message-service/with/${id}?page=${pageNum}&size=10`,
         {
           headers: { Authorization: `Bearer ${token}` },
         }
@@ -198,8 +198,8 @@ export const MessageRoom = () => {
     const fetchTargetUserInfo = async () => {
       try {
         const token = localStorage.getItem("jwtToken");
-        const response = await axios.get(
-          "https://a-log.site/api/message-service/rooms",
+        const response = await api.get(
+          "/message-service/rooms",
           {
             headers: { Authorization: `Bearer ${token}` },
           }
@@ -328,7 +328,7 @@ export const MessageRoom = () => {
       }
       // REST 동기화
       const token = localStorage.getItem("jwtToken");
-      axios.get("https://a-log.site/api/message-service/count/unread", {
+      api.get("/message-service/count/unread", {
         headers: { Authorization: `Bearer ${token}` }
       })
       .then(res => {

--- a/src/screens/MessageRoomExit/MessageRoomExit.jsx
+++ b/src/screens/MessageRoomExit/MessageRoomExit.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import axios from "axios";
+import api from "../../api/instance";
 import "./MessageRoomExit.css";
 
 export const MessageRoomExit = ({ onClose }) => {
@@ -10,8 +10,8 @@ export const MessageRoomExit = ({ onClose }) => {
   const handleLeave = async () => {
     try {
       const token = localStorage.getItem("jwtToken");
-      await axios.post(
-        `https://a-log.site/api/message-service/room/exit/${id}`,
+      await api.post(
+        `/message-service/room/exit/${id}`,
         {},
         {
           headers: { Authorization: `Bearer ${token}` },

--- a/src/screens/Notice/Notice.jsx
+++ b/src/screens/Notice/Notice.jsx
@@ -6,11 +6,7 @@ import SelectModeScreen from "../SelectModeScreen/SelectModeScreen";
 import ScrollUp from "../../icons/ScrollUp/ScrollUp";
 import Navbar2 from "../../components/Navbar2/Navbar2";
 import "./Notice.css";
-import axios from "axios";
-
-const api = axios.create({
-  baseURL: "https://a-log.site/api/alarm-service",
-});
+import api from "../../api/instance";
 
 function NotificationItem({
   notice,

--- a/src/screens/SignUp/SignUp.css
+++ b/src/screens/SignUp/SignUp.css
@@ -153,7 +153,7 @@
 }
 
 .sign-up-screen .text-wrapper-21 {
-  align-self: stretch;
+  /* align-self: stretch;
   color: #d9d9d9;
   flex: 1;
   font-family: "Inter", Helvetica;
@@ -162,7 +162,18 @@
   letter-spacing: 0;
   line-height: 10px;
   margin-top: -0.50px;
-  position: relative;
+  position: relative; */
+  color: #000000;
+  font-family: "Inter", Helvetica;
+  font-size: 15px;
+  font-weight: 400;
+  left: 68px;
+  letter-spacing: 0;
+  line-height: 10px;
+  position: absolute;
+  text-align: center;
+  top: 188px;
+  white-space: nowrap;
 }
 
 .sign-up-screen .text-wrapper-22 {

--- a/src/screens/SignUp/SignUp.jsx
+++ b/src/screens/SignUp/SignUp.jsx
@@ -24,6 +24,7 @@ export const SignUp = () => {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [confirmMessage, setConfirmMessage] = useState("");
   const [name, setName] = useState("");
+  const [nicknameMessage, setNicknameMessage] = useState("");
 
   const handleConfirmCode = async () => {
     if (!email || !verificationCode) {
@@ -105,6 +106,24 @@ export const SignUp = () => {
     }
   };
 
+  // 닉네임 중복 확인 함수
+  const handleCheckNickname = async () => {
+    if (!nickname) {
+      setNicknameMessage("닉네임을 입력해주세요.");
+      return;
+    }
+    try {
+      const res = await api.get(`/user-service/check-nickname/${nickname}`);
+      if (res.data.data === true) {
+        setNicknameMessage("이미 사용 중인 닉네임입니다.");
+      } else {
+        setNicknameMessage("사용 가능한 닉네임입니다.");
+      }
+    } catch (error) {
+      setNicknameMessage(error.response?.data?.message || "닉네임 중복 확인에 실패했습니다.");
+    }
+  };
+
   return (
     <PageTransitionWrapper>
       <Component18 className="component-18" />
@@ -131,10 +150,17 @@ export const SignUp = () => {
                 value={nickname}
                 onChange={(e) => setNickname(e.target.value)}
               />
-              <div className={`frame-2 ${nickname ? "active" : ""}`}>
-                <div className="text-wrapper-19">Check availability</div>
+              <div
+                className={`frame-2 ${nickname ? "active" : ""}`}
+                onClick={handleCheckNickname}
+                style={{ cursor: "pointer" }}
+              >
+                <div className="text-wrapper-19">중복 확인</div>
               </div>
             </div>
+            {nicknameMessage && (
+              <div className="text-wrapper-21">{nicknameMessage}</div>
+            )}
 
             <div className="password-2">
               <CommunicationMail className="user-user-card-ID" />

--- a/src/screens/SignUp/SignUp.jsx
+++ b/src/screens/SignUp/SignUp.jsx
@@ -10,6 +10,7 @@ import UserUserCardId from "../../icons/UserUserCardId/UserUserCardId";
 import PageTransitionWrapper from "../../components/PageTransitionWrapper/PageTransitionWrapper";
 import AlogLogo from "../../icons/AlogLogo/AlogLogo";
 import "./SignUp.css";
+import api from "../../api/instance";
 
 export const SignUp = () => {
   const [nickname, setNickname] = useState("");
@@ -22,14 +23,20 @@ export const SignUp = () => {
   const [passwordMessage, setPasswordMessage] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [confirmMessage, setConfirmMessage] = useState("");
+  const [name, setName] = useState("");
 
-  const handleConfirmCode = () => {
-    if (verificationCode === realCode) {
+  const handleConfirmCode = async () => {
+    if (!email || !verificationCode) {
+      alert("이메일과 인증번호를 모두 입력해주세요.");
+      return;
+    }
+    try {
+      await api.post("/user-service/verify/check", { email, code: verificationCode });
       setIsCodeValid(true);
       alert("인증에 성공했습니다.");
-    } else {
+    } catch (error) {
       setIsCodeValid(false);
-      alert("인증 코드가 일치하지 않습니다.");
+      alert(error.response?.data?.message || "인증에 실패했습니다.");
     }
   };
 
@@ -61,12 +68,41 @@ export const SignUp = () => {
     }
   };
 
-  const handleSendEmail = () => {
+  const handleSendEmail = async () => {
     if (!email) {
       setEmailMessage("이메일을 입력해주세요.");
       return;
     }
-    setEmailMessage("인증번호가 발송되었습니다.");
+    try {
+      await api.post("/user-service/verify/send", { email });
+      setEmailMessage("인증번호가 발송되었습니다.");
+    } catch (error) {
+      setEmailMessage(error.response?.data?.message || "인증번호 발송에 실패했습니다.");
+    }
+  };
+
+  const handleSignUp = async (e) => {
+    e.preventDefault();
+    if (password !== confirmPassword) {
+      setConfirmMessage("비밀번호가 일치하지 않습니다.");
+      return;
+    }
+    // 회원가입 API 요청
+    try {
+      const formData = new FormData();
+      formData.append("email", email);
+      formData.append("name", name);
+      formData.append("password", password);
+      formData.append("nickname", nickname);
+      formData.append("role", "USER"); // 기본값 USER, 필요시 선택값으로 변경
+      // githubUsername, profileImage 등 추가 가능
+
+      await api.post("/user-service/signup", formData);
+      alert("회원가입이 완료되었습니다. 로그인 해주세요.");
+      window.location.href = "/login";
+    } catch (error) {
+      alert(error.response?.data?.message || "회원가입에 실패했습니다.");
+    }
   };
 
   return (
@@ -81,6 +117,8 @@ export const SignUp = () => {
                 type="text"
                 placeholder="Enter your name"
                 className="text-input"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
               />
             </div>
 
@@ -171,11 +209,9 @@ export const SignUp = () => {
               />
             </div>
 
-            <Link to="/login">
-              <button className="login-button">
-                <div className="LOGIN">Sign up</div>
-              </button>
-            </Link>
+            <button className="login-button" onClick={handleSignUp}>
+              <div className="LOGIN">Sign up</div>
+            </button>
           </div>
 
           <Link to="/">


### PR DESCRIPTION
## 📌 Jira Issue

- 관련 티켓: [GUC-167](https://sh0314.atlassian.net/browse/GUC-167)
- 관련 GitHub 이슈: #62 

---

## ✨ PR Description

- 로그인, 회원 가입 API 연동
- 로그인 시 refresh Token, access Token, userId 로컬 스토리지에 저장
- access Token 만료되면 refresh Token으로 access Token 자동 발급
- WebSocket 연결 끊기지 않도록 30초 주기로 서버에 ping 메시지 전송
---

## 📝 Requirements for Reviewer

- 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 여기에 적어주세요
    - ex) 메서드 `handleLoginRedirect()` 명칭 괜찮은지 봐주세요
    - ex) 코드 로직 중 `line 45~56` 성능 개선 가능할지 궁금합니다

---

## ✅ 체크리스트

- [ ] Jira 티켓 번호를 커밋 메시지에 포함했는가?
- [ ] GitHub 이슈에 `resolves: #번호`를 추가했는가?
- [ ] 불필요한 주석, 디버깅 코드 제거했는가?
- [ ] 기능 테스트 및 정상 동작 확인했는가?

---

## 📸 스크린샷 (선택)

> UI 변경 사항이 있다면 여기에 첨부해주세요 (Drag & Drop 가능)

---

## 🔍 기타 참고사항

> 리뷰어에게 공유하고 싶은 추가 정보가 있다면 여기에 작성해주세요

[GUC-167]: https://sh0314.atlassian.net/browse/GUC-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ