### PR TITLE
카테고리 페이지에서 정렬버튼 검색박스 내부로 위치 변경

### DIFF
--- a/src/components/SortButton/SortButton.css
+++ b/src/components/SortButton/SortButton.css
@@ -7,7 +7,7 @@
   justify-content: center;
   gap: 10px;
   padding: 12px 20px;
-  border: 2px solid #1d1652;
+  border: none;
   border-radius: 10px;
   box-sizing: border-box;
   cursor: pointer;

--- a/src/screens/Community/Community.css
+++ b/src/screens/Community/Community.css
@@ -34,6 +34,7 @@
   width: 100%;
   max-width: 800px;
   margin: 40px auto;
+  overflow: visible;
 }
 
 .community-keyword-box {
@@ -49,8 +50,16 @@
   position: relative;
   box-shadow: 0 4px 20px rgba(29, 22, 82, 0.08), inset 0 0 0 2px #e8f2ff;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  overflow: hidden;
+  overflow: visible;
   max-width: 500px;
+}
+
+.community-keyword-box > :first-child {
+  padding: 0;
+  margin: 0;
+  align-self: stretch;
+  display: flex;
+  align-items: center;
 }
 
 .community-keyword-box:focus-within {
@@ -106,9 +115,9 @@
 
 .community-input {
   flex: 1;
-  padding: 18px 24px;
+  padding: 18px 16px;
   border: none;
-  border-radius: 16px 0 0 16px;
+  border-radius: 0;
   font-size: 16px;
   font-family: 'GmarketSans', sans-serif;
   font-weight: 400;

--- a/src/screens/Community/Community.jsx
+++ b/src/screens/Community/Community.jsx
@@ -52,7 +52,7 @@ export const Community = () => {
       setSearchResults(res.data.postList);
       setSearchPage(res.data.pageNumber);
       setSearchTotalPages(res.data.totalPages);
-    } catch (err) {
+    } catch {
       setSearchResults([]);
     }
   };
@@ -67,6 +67,7 @@ export const Community = () => {
           {/* 검색창 + 모집 버튼 */}
           <div className="community-frame-keyword">
             <div className="community-keyword-box">
+              <SortButton onChange={setSelectedSort} />
               <input
                 type="text"
                 className="community-input"
@@ -100,9 +101,7 @@ export const Community = () => {
             onTabChange={setSelectedCategory}
           />
 
-          <div className="community-frame-sort">
-            <SortButton onChange={setSelectedSort} />
-          </div>
+
 
           {/* 검색어가 있으면 검색 결과만, 없으면 기존 카테고리별 목록 */}
           {searchKeyword.trim() ? (


### PR DESCRIPTION
## 📌 Jira Issue

- 관련 티켓: [GUC-274](https://sh0314.atlassian.net/browse/GUC-274)
- 관련 GitHub 이슈: #198

---

## ✨ PR Description

- 변경 사항 설명:
    - 정렬 버튼 검색 시에만 적용됨을 명확히 알 수 있도록 버튼 위치 변경

---

## 📝 Requirements for Reviewer

- 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 여기에 적어주세요

---

## ✅ 체크리스트

- [x] 정렬 버튼 검색 시에만 적용됨을 명확히 알 수 있도록 버튼 위치 변경

---

## 📸 스크린샷 (선택)

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/10ba720b-907b-4c65-bf34-ab907f14d4b9" />

---

## 🔍 기타 참고사항

> 리뷰어에게 공유하고 싶은 추가 정보가 있다면 여기에 작성해주세요

[GUC-274]: https://sh0314.atlassian.net/browse/GUC-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ